### PR TITLE
Fix cloning of postMessage object; matches could include functions

### DIFF
--- a/templates/ts/app/root.ts
+++ b/templates/ts/app/root.ts
@@ -7,23 +7,23 @@ React.useEffect(() => {
   isMount = false;
   if ("serviceWorker" in navigator) {
     if (navigator.serviceWorker.controller) {
-      navigator.serviceWorker.controller?.postMessage({
+      navigator.serviceWorker.controller?.postMessage(JSON.stringify({
         type: "REMIX_NAVIGATION",
         isMount: mounted,
         location,
         matches,
         manifest: window.__remixManifest,
-      });
+      }));
     } else {
       let listener = async () => {
         await navigator.serviceWorker.ready;
-        navigator.serviceWorker.controller?.postMessage({
+        navigator.serviceWorker.controller?.postMessage(JSON.stringify({
           type: "REMIX_NAVIGATION",
           isMount: mounted,
           location,
           matches,
           manifest: window.__remixManifest,
-        });
+        }));
       };
       navigator.serviceWorker.addEventListener("controllerchange", listener);
       return () => {


### PR DESCRIPTION
[useMatches](https://remix.run/docs/en/v1/api/remix#usematches) returns a `handle` which can return functions (which they do in my app).  `postMessage` here fails to clone in that case.  Adding JSON.stringify resolves the issue in my case.