### PR TITLE
feat: allow cli to accept options

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
   },
   "dependencies": {
     "@babel/preset-typescript": "^7.16.7",
+    "arg": "^5.0.2",
     "chalk": "4.1.2",
     "colorette": "^2.0.16",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
Currently cli doesn't accept any options but for improved DX it will be a good idea to allow cli to accept initial command line options. This PR adds this feature to the cli. Choices whose initial options were passed will be skipped and won't be asked.

for e.g. if the `--ts` option is passed it `enquirer` won't prompt for `lang`.

```
npx remix-pwa --ts
```

## Options

 `--typescript`, `--ts`    ->    Create project with typescript template
 `--no-typescript`, `--no-ts`  -> Create project with javascript template
`--install`       ->              Install the dependencies after creating.
`--no-install`       ->       Skip the installation process
`--cache`         ->         Preferred \`Caching Strategy\` for the service worker. Either \`jit\` or \`pre\`
`--features`, `--feat`    ->    `remix-pwa` features user wants to include should be wrapped as a string e.g. `'sw, manifest, push'`
    - `'sw'` for Service Workers
    - `'manifest'` for Web Manifest
    - `'push'` for Push Notifications
    - `'utils'` for PWA Client Utilities
    - `'icons'` for Development Icons
    
 `--dir`          ->           The location of Remix \`app\` directory
 `--help`, `-h`        ->        Print help message
 `--version`, `-v`     ->        Print the CLI version