### PR TITLE
fix: sendnotification returning undefined

### DIFF
--- a/templates/js/app/utils/client/pwa-utils.client.js
+++ b/templates/js/app/utils/client/pwa-utils.client.js
@@ -5,7 +5,7 @@
 */
 
 /* 
-  ⚠ Except you understand & know the implication of what you're what you are doing, don't modify this file! ⚠
+  ⚠ Except you understand & know the implication of what you're doing, don't modify this file! ⚠
 */
 
 // Clipboard Copy API
@@ -228,7 +228,7 @@ export async function ExitFullScreenMode() {
 export async function SendNotification(title, options) {
   try {
     if ("Notification" in window) {
-      const permissions = await (await navigator.permissions.query({ name: "notifications" })).state;
+      const permissions = (await navigator.permissions.query({ name: "notifications" })).state;
       navigator.permissions.query({ name: "notifications" }).then((permissionStatus) => {
         if (permissionStatus.state === "granted") {
           return;
@@ -238,13 +238,12 @@ export async function SendNotification(title, options) {
       });
 
       if (permissions === "granted") {
-        await navigator.serviceWorker.ready.then((registration) => {
-          registration.showNotification(title, options);
-          return {
-            status: "success",
-            message: "Sent Notification to user successfully",
-          };
-        });
+        const registration = await navigator.serviceWorker.ready
+        await registration.showNotification(title, options);
+        return {
+          status: "success",
+          message: "Sent Notification to user successfully",
+        };
       } else {
         return {
           status: "bad",
@@ -322,7 +321,7 @@ export async function copyImage(url) {
       ]);
       return {
         status: "success",
-        message: "Image copied successfully successfully!",
+        message: "Image copied successfully!",
       };
     } else {
       return {

--- a/templates/ts/app/utils/client/pwa-utils.client.ts
+++ b/templates/ts/app/utils/client/pwa-utils.client.ts
@@ -246,7 +246,7 @@ interface NotificationOptions {
 export async function SendNotification(title: string, options: NotificationOptions): Promise<ResponseObject> {
   try {
     if ("Notification" in window) {
-      const permissions = await (await navigator.permissions.query({ name: "notifications" })).state;
+      const permissions = (await navigator.permissions.query({ name: "notifications" })).state;
       navigator.permissions.query({ name: "notifications" }).then((permissionStatus) => {
         if (permissionStatus.state === "granted") {
           return;
@@ -256,13 +256,12 @@ export async function SendNotification(title: string, options: NotificationOptio
       });
 
       if (permissions === "granted") {
-        await navigator.serviceWorker.ready.then((registration) => {
-          registration.showNotification(title, options);
-          return {
-            status: "success",
-            message: "Sent Notification to user successfully",
-          };
-        });
+        const registration = await navigator.serviceWorker.ready
+        await registration.showNotification(title, options);
+        return {
+          status: "success",
+          message: "Sent Notification to user successfully",
+        };
       } else {
         return {
           status: "bad",
@@ -340,7 +339,7 @@ export async function copyImage(url: string): Promise<ResponseObject> {
       ]);
       return {
         status: "success",
-        message: "Image copied successfully successfully!",
+        message: "Image copied successfully!",
       };
     } else {
       return {


### PR DESCRIPTION
`SendNotification` from client-utils was returning undefined if the operation was successful. This is because the return statement was missing. Also were not awaiting for the promise returned by `registration.sendNotification`. This PR fixes those both issues.