### PR TITLE
make manifest loaders async

### DIFF
--- a/templates/js/app/routes/resources/manifest[.]json.js
+++ b/templates/js/app/routes/resources/manifest[.]json.js
@@ -1,6 +1,6 @@
 import { json } from "@remix-run/node";
 
-export let loader = () => {
+export let loader = async () => {
   return json(
     {
       short_name: "PWA",

--- a/templates/ts/app/routes/resources/manifest[.]json.ts
+++ b/templates/ts/app/routes/resources/manifest[.]json.ts
@@ -1,7 +1,7 @@
 import { json } from "@remix-run/node";
 import type { LoaderFunction } from "@remix-run/node";
 
-export let loader: LoaderFunction = () => {
+export let loader: LoaderFunction = async () => {
   return json(
     {
       short_name: "PWA",


### PR DESCRIPTION
Loaders from resource routes which are supposed to return manifest data are also supposed to be asynchronous function.